### PR TITLE
feat(kafka-poc): add simplified Docker Compose setup for local Kafka

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,100 +1,38 @@
 services:
-  controller-1:
+  controller:
     image: docker.io/apache/kafka:latest
-    container_name: controller-1
+    container_name: controller
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: controller
       KAFKA_LISTENERS: CONTROLLER://:9093
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller:9093
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+    networks:
+      - kafka-net
 
-  controller-2:
+  broker:
     image: docker.io/apache/kafka:latest
-    container_name: controller-2
-    environment:
-      KAFKA_NODE_ID: 2
-      KAFKA_PROCESS_ROLES: controller
-      KAFKA_LISTENERS: CONTROLLER://:9093
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-
-  controller-3:
-    image: docker.io/apache/kafka:latest
-    container_name: controller-3
-    environment:
-      KAFKA_NODE_ID: 3
-      KAFKA_PROCESS_ROLES: controller
-      KAFKA_LISTENERS: CONTROLLER://:9093
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-
-  broker-1:
-    image: docker.io/apache/kafka:latest
-    container_name: broker-1
+    container_name: broker
+    # expose Kafka to your host on localhost:29092
     ports:
       - 29092:9092
     environment:
-      KAFKA_NODE_ID: 4
+      KAFKA_NODE_ID: 2
       KAFKA_PROCESS_ROLES: broker
-      KAFKA_LISTENERS: 'PLAINTEXT://:19092,PLAINTEXT_HOST://:9092'
-      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker-1:19092,PLAINTEXT_HOST://localhost:29092'
+      # internal (cluster) listener + host listener
+      KAFKA_LISTENERS: PLAINTEXT://:19092,PLAINTEXT_HOST://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:19092,PLAINTEXT_HOST://localhost:29092
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller:9093
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
     depends_on:
-      - controller-1
-      - controller-2
-      - controller-3
-
-  broker-2:
-    image: docker.io/apache/kafka:latest
-    container_name: broker-2
-    ports:
-      - 39092:9092
-    environment:
-      KAFKA_NODE_ID: 5
-      KAFKA_PROCESS_ROLES: broker
-      KAFKA_LISTENERS: 'PLAINTEXT://:19092,PLAINTEXT_HOST://:9092'
-      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker-2:19092,PLAINTEXT_HOST://localhost:39092'
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-    depends_on:
-      - controller-1
-      - controller-2
-      - controller-3
-
-  broker-3:
-    image: docker.io/apache/kafka:latest
-    container_name: broker-3
-    ports:
-      - 49092:9092
-    environment:
-      KAFKA_NODE_ID: 6
-      KAFKA_PROCESS_ROLES: broker
-      KAFKA_LISTENERS: 'PLAINTEXT://:19092,PLAINTEXT_HOST://:9092'
-      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker-3:19092,PLAINTEXT_HOST://localhost:49092'
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-    depends_on:
-      - controller-1
-      - controller-2
-      - controller-3
-
+      - controller
+    networks:
+      - kafka-net
 
   kafka-ui:
     image: docker.io/provectuslabs/kafka-ui:latest
@@ -103,8 +41,11 @@ services:
       - 8080:8080
     environment:
       KAFKA_CLUSTERS_0_NAME: local-kafka
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: broker-1:19092,broker-2:19092,broker-3:19092
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: broker:19092
     depends_on:
-      - broker-1
-      - broker-2
-      - broker-3
+      - broker
+    networks:
+      - kafka-net
+
+networks:
+  kafka-net:


### PR DESCRIPTION
- Introduced docker-compose.yml using Kafka in KRaft mode (no ZooKeeper)
- Single-broker configuration for fast, lightweight local development
- Added Provectus Kafka UI for topic and message management
- Enabled auto-create-topics to speed up prototyping
- Minimal, easy-to-run setup for proof-of-concept work